### PR TITLE
fix json includes

### DIFF
--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <json/json.h>
+#include <jsoncpp/json/json.h>
 
 #include <Eigen/Eigen>
 #include <set>

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -1,6 +1,6 @@
 #include "ouster/client.h"
 
-#include <json/json.h>
+#include <jsoncpp/json/json.h>
 
 #include <algorithm>
 #include <cerrno>

--- a/ouster_client/src/types.cpp
+++ b/ouster_client/src/types.cpp
@@ -1,6 +1,6 @@
 #include "ouster/types.h"
 
-#include <json/json.h>
+#include <jsoncpp/json/json.h>
 
 #include <Eigen/Eigen>
 #include <algorithm>


### PR DESCRIPTION
Fixed build error caused by missing `#include <json/json.h>` by replacing it with `#include <jsoncpp/json/json.h>`.